### PR TITLE
ignore symlinks while reading files

### DIFF
--- a/helm/helm.go
+++ b/helm/helm.go
@@ -98,7 +98,7 @@ func LoadChart(ctx context.Context, f fs.FS) (*Chart, error) {
 			return err
 		}
 
-		if d.IsDir() {
+		if d.IsDir() || d.Type() == fs.ModeSymlink {
 			return nil
 		}
 


### PR DESCRIPTION
While using this lib, I discovered that loading a chart crashes if a symlink is inside the chart. This solves this.